### PR TITLE
convert timestamp string to Number() for formatting

### DIFF
--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -144,7 +144,7 @@ const ReleaseBox = ({ release, timestamp, passed, passing, total, link }) => {
             <div name="inner-container">
               <div className={releaseTitle}>
                 <h3 name="releasebox-title">Release: #{release}</h3>{" "}
-                <p name="releasebox-timestamp">{timestamp.toGMTString()}</p>
+                <p name="releasebox-timestamp">{timestamp}</p>
               </div>
               <div className={releaseBadges}>
                 <span

--- a/compliance-ui/components/controlbox/ControlBox.js
+++ b/compliance-ui/components/controlbox/ControlBox.js
@@ -1,6 +1,7 @@
 import { Header } from "./Header";
 import { Footer } from "./Footer";
 import { WithLink } from "./WithLink";
+import { formatTimestamp } from "../../util";
 
 export const ControlBox = ({
   id,
@@ -15,6 +16,7 @@ export const ControlBox = ({
   titleTimestamp,
   tab
 }) => {
+  var formattedDate = formatTimestamp(timestamp);
   return (
     <li
       tabIndex={tab}
@@ -27,13 +29,13 @@ export const ControlBox = ({
           <Header
             title={title}
             status={status}
-            timestamp={timestamp}
+            timestamp={formattedDate}
             titleTimestamp={titleTimestamp}
           />
           <Footer
             status={status}
             description={description}
-            timestamp={timestamp}
+            timestamp={formattedDate}
             references={references}
             component={component}
             titleTimestamp={titleTimestamp}

--- a/compliance-ui/pages/index.js
+++ b/compliance-ui/pages/index.js
@@ -5,7 +5,7 @@ import Layout from "../components/Layout";
 import ReleaseBox from "../components/ReleaseBox";
 import { releaseStatus } from "../api";
 import { format, parse } from "date-fns";
-import { getReleases } from "../util";
+import { getReleases, formatTimestamp } from "../util";
 
 const releases = css`
   margin: ${theme.spacing.xl} ${theme.spacing.xxl} 0 ${theme.spacing.xxl};
@@ -48,21 +48,21 @@ if (typeof window !== "undefined") {
 }
 
 const ReleasesPage = ({ data }) => {
-  console.log(data);
   return (
     <Layout>
       <div className={releases}>
         <h1> Latest Releases: </h1>
         <ul className={releaseList}>
           {data.releases.map((singleRelease, index) => {
-            var myDate = new Date(singleRelease.timestamp * 1000);
+            var myDate = Number(singleRelease.timestamp);
+            var formattedDate = formatTimestamp(myDate);
             const key = `${singleRelease.release}`;
-            console.log(singleRelease.timestamp);
+
             return (
               <ReleaseBox
                 release={singleRelease.release}
                 passed={singleRelease.passed}
-                timestamp={myDate}
+                timestamp={formattedDate}
                 passing={singleRelease.passing}
                 total={singleRelease.total}
                 link={`/singlerelease/${key}`}

--- a/compliance-ui/pages/singleRelease.js
+++ b/compliance-ui/pages/singleRelease.js
@@ -67,7 +67,7 @@ class SingleReleasePage extends React.Component {
         <div data-testid="home" className={home}>
           <a name="back" href="/" className={back}>
             <BackIcon fill={theme.colour.blackLight} />
-            Back to main page
+            Back to home
           </a>
           <IsReady
             data={data}


### PR DESCRIPTION
## This PR consists of the following:
- The timestamp was not being converted properly because it was actually a string `("12345")` as opposed to `(12345)`.
- Running the `Number()` function on it before parsing it, seems to solve this.