### PR TITLE
Cannot read property 'map' of undefined

### DIFF
--- a/web-report/src/pages/HomePage.js
+++ b/web-report/src/pages/HomePage.js
@@ -3,6 +3,7 @@ import React from "react";
 import { jsx, css } from "@emotion/core";
 import Layout from "../components/Layout";
 import Home from "../components/Home";
+import { Failed } from "../components";
 import { releaseStatus } from "../../api/index";
 import "./Home.css";
 
@@ -23,6 +24,11 @@ class HomePage extends React.Component {
 
   render() {
     const { data } = this.state;
+
+    if (!data || data.length < 1) {
+      return <Failed />;
+    }
+
     return (
       <Layout>
         <Home sortedData={data} />


### PR DESCRIPTION
Fixes "Cannot read property 'map' of undefined"

If no data is available this will now show a "failed to fetch" screen.


**Current:**
<img width="721" alt="Screen Shot 2019-06-06 at 7 57 32 AM" src="https://user-images.githubusercontent.com/62242/59031130-daaba300-8830-11e9-8ffd-8579204abb68.png">

**New:**
<img width="786" alt="Screen Shot 2019-06-06 at 7 56 10 AM" src="https://user-images.githubusercontent.com/62242/59031150-e5663800-8830-11e9-9c52-88a653af8443.png">

