### PR TITLE
Add dev script alias

### DIFF
--- a/web-report/package.json
+++ b/web-report/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start": "razzle start",
+    "dev": "razzle start",
     "build": "razzle build",
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"


### PR DESCRIPTION
This adds dev to the run scripts.

When working between the API + the Web Report the run commands are different.  This allows to run either start or dev with the same result.
```
"scripts": {
    "start": "razzle start",
    "dev": "razzle start",
```