### PR TITLE
API is still missing files to ingress

### DIFF
--- a/api/src/db/save.ts
+++ b/api/src/db/save.ts
@@ -164,11 +164,21 @@ const q = queue(async (item: File, cb: (item: File) => {}) => {
   cb(item);
 }, 1);
 
+let drainCounter = 1;
+
 q.drain(async () => {
   console.log("all items have been processed");
   const files = await getFileData();
-  console.log("hey we've missed these files");
-  console.log(files);
+  console.log(`missed files count ${files.length} `);
+  // limit the # of attempts we make so we don't end
+  // up in an endless loop
+  if (drainCounter < 5) {
+    await saveFiles();
+    console.log(`drain count ${drainCounter}`);
+    drainCounter++;
+  } else {
+    console.log("reached drain call limit");
+  }
 });
 
 export const saveFiles = async () => {

--- a/api/src/db/save.ts
+++ b/api/src/db/save.ts
@@ -2,8 +2,7 @@ import queue from "async/queue";
 import { File } from "../interfaces/File";
 import { note } from "../utils/note";
 import { renameFile } from "../utils/renameFile";
-
-const { getFiles } = require("./getFiles");
+import { getFiles } from "./getFiles";
 const { checkExists, saveReleaseToDB } = require("./queries");
 const merge = require("object-array-merge");
 const { forceBoolean } = require("../utils/forceBoolean");
@@ -164,6 +163,13 @@ const q = queue(async (item: File, cb: (item: File) => {}) => {
   await queueCB(item);
   cb(item);
 }, 1);
+
+q.drain(async () => {
+  console.log("all items have been processed");
+  const files = await getFileData();
+  console.log("hey we've missed these files");
+  console.log(files);
+});
 
 export const saveFiles = async () => {
   try {


### PR DESCRIPTION
Fix for https://github.com/cds-snc/security-goals/issues/122

When the q has emptied (drained) q.drain will get called.

At this point we check to see if we've missed files.  If we have we call saveFiles again.

I've capped this at 5 calls for now to avoid possible issues with creating an endless loop.

