### PR TITLE
Update API to prep for range queries

### DIFF
--- a/api/src/db/__tests__/flattenAndSave.test.js
+++ b/api/src/db/__tests__/flattenAndSave.test.js
@@ -22,7 +22,7 @@ describe("flattenAndSave", () => {
   it("keeps existing control data", async () => {
     const result = await flattenAndSave(fixture, mockSave);
     expect(mockSave.mock.calls.length).toBe(1);
-    expect(result.controls[0].control).toEqual("CA-2 (7)");
+    expect(result.controls[0].control).toEqual("CA-2 (2)");
   });
 
   it("keeps existing release data", async () => {

--- a/api/src/db/queries.ts
+++ b/api/src/db/queries.ts
@@ -7,7 +7,7 @@ const note = message => {
   log(chalk.black.bgGreen("\n\n" + message));
 };
 
-const getControl = async control => {
+export const getControl = async control => {
   note(`=== get control ===`);
 
   // @todo update this query to target single release
@@ -29,7 +29,7 @@ const getControl = async control => {
       },
       {
         $sort: {
-          _id: 1
+          _id: 1,
         },
       },
     ])
@@ -100,6 +100,25 @@ const unwindReleaseControls = async sha => {
     .exec();
 };
 
+export const getMinMaxReleaseDates = async () => {
+  const max = await releaseModel
+    .find({})
+    .sort({ releaseTimeStamp: -1 })
+    .limit(1)
+    .exec();
+
+  const min = await releaseModel
+    .find({})
+    .sort({ releaseTimeStamp: 1 })
+    .limit(1)
+    .exec();
+
+  return {
+    min: min[0].releaseTimeStamp,
+    max: max[0].releaseTimeStamp,
+  };
+};
+
 const getReleaseDate = async results => {
   let release = results[0].controls.verifications[0].release;
   let d = new Date(0);
@@ -135,6 +154,7 @@ const updateRelease = async (sha, { passing, total }, releaseDate) => {
 };
 
 module.exports = {
+  getMinMaxReleaseDates,
   getControl,
   sumRelease,
   checkExists,

--- a/api/src/db/save.ts
+++ b/api/src/db/save.ts
@@ -77,12 +77,13 @@ export const flattenAndSave = async (
   const result = await checkExists(obj);
 
   // check if there's an existing release
-  if (!result.length) {
+  if (!result || !result.length) {
     // @ts-ignore
     return save(obj);
   }
 
   const existingControls = result[0].controls;
+
   const newControls = checkControlExists(obj.controls, existingControls);
 
   if (newControls.length >= 1) {

--- a/api/src/resolvers/releaseDates.ts
+++ b/api/src/resolvers/releaseDates.ts
@@ -1,0 +1,16 @@
+import { ReleasesMixMax } from "../types/ReleaseDates";
+import { getMinMaxReleaseDates } from "../db/queries";
+
+export const releasesMinMax = {
+  description: "Returns min and max release dates",
+  type: ReleasesMixMax,
+  args: {},
+  // eslint-disable-next-line no-unused-vars
+  resolve: async (root, {}, context, info) => {
+    try {
+      return await getMinMaxReleaseDates();
+    } catch (e) {
+      console.log(e);
+    }
+  },
+};

--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -3,6 +3,7 @@ const { controls } = require("./resolvers/controls");
 const { controlReleases } = require("./resolvers/controlReleases");
 const { releases } = require("./resolvers/releases");
 const { latest } = require("./resolvers/latest");
+const { releasesMinMax } = require("./resolvers/releaseDates");
 
 const query = new GraphQLObjectType({
   name: "Query",
@@ -11,6 +12,7 @@ const query = new GraphQLObjectType({
     controlReleases,
     releases,
     latest,
+    releasesMinMax,
   },
 });
 

--- a/api/src/types/Release.js
+++ b/api/src/types/Release.js
@@ -15,6 +15,10 @@ const Release = new GraphQLObjectType({
       description: "release timestamp when the release was created",
       type: GraphQLString,
     },
+    formattedReleaseTimeStamp: {
+      description: "formatted release timestamp %H:%M:%S %d-%m-%Y",
+      type: GraphQLString,
+    },
     controls: { description: "timestamp", type: new GraphQLList(Control) },
     passed: {
       description: "status to determine if all controls for the release passed",

--- a/api/src/types/ReleaseDates.ts
+++ b/api/src/types/ReleaseDates.ts
@@ -1,0 +1,17 @@
+const { GraphQLObjectType, GraphQLString } = require("graphql");
+
+export const ReleasesMixMax = new GraphQLObjectType({
+  name: "ReleasesMixMax",
+  description:
+    "Return min and max Release timestamp.  Helpful for date range queries",
+  fields: () => ({
+    min: {
+      description: "timestamp - the earliest release timestamp",
+      type: GraphQLString,
+    },
+    max: {
+      description: "timestamp - the latest release timestamp",
+      type: GraphQLString,
+    },
+  }),
+});


### PR DESCRIPTION
This PR adds the ability to query using a date range

Both fields are optional.  When passing just a startDate the endDate will default to today
```
{
  releases(startDate:"2019-05-10", endDate:"2019-05-19") {
    _id
    release
    timestamp
    releaseTimeStamp
    formattedReleaseTimeStamp
    passed
    passing
    total
  }
}
```

I also added a new resolver to query for the minimum start and maximum end date for releases which we'll need https://github.com/cds-snc/security-goals/issues/90.
```
{
  releasesMinMax {
    min
    max
  }
}
```