### PR TITLE
Restrict date filter between min / max dates based on releases

### DIFF
--- a/web-report/src/__tests__/__page_tests__/index-page.test.js
+++ b/web-report/src/__tests__/__page_tests__/index-page.test.js
@@ -4,11 +4,17 @@ import 'react-dates/lib/css/_datepicker.css';
 import { cleanup, render, wait} from "@testing-library/react";
 import { data } from "../../__mocks__/mockDataIndex.js";
 import "jest-dom/extend-expect";
-import { releaseStatus } from "../../../api/index";
+import { releaseStatus, minMaxDates } from "../../../api/index";
 import { MemoryRouter } from 'react-router-dom';
 
 jest.mock("../../../api/index", () => ({
-  releaseStatus: jest.fn()
+  releaseStatus: jest.fn(),
+  minMaxDates: function() {
+    return {releasesMinMax: {
+    min: 0,
+    max: 0
+    }}
+  }
 }));
 
 jest.mock("../../../src/config", () => ({

--- a/web-report/src/components/Home.js
+++ b/web-report/src/components/Home.js
@@ -66,8 +66,6 @@ class Home extends React.Component {
       minDate: dates.releasesMinMax.min,
       maxDate: dates.releasesMinMax.max
     });
-    console.log("min: " + dates.releasesMinMax.min);
-    console.log("max: " + dates.releasesMinMax.max);
   };
   render () {
     const {keyDownUL, sortedData, keyDownAllReleases} = this.props;

--- a/web-report/src/components/Home.js
+++ b/web-report/src/components/Home.js
@@ -6,6 +6,7 @@ import { formatTimestamp } from "../util";
 import { runtimeConfig } from '../config';
 import { I18N } from "./I18N";
 import { DateRangePicker } from 'react-dates';
+import { minMaxDates } from "../../api/index";
 import React from "react";
 
 const releases = css`
@@ -54,9 +55,20 @@ class Home extends React.Component {
     this.state = {
       startDate: null,
       endDate: null,
-      focusedInput: null
+      focusedInput: null,
+      minDate: null,
+      maxDate: null
     }
   }
+  componentDidMount = async () => {
+    const dates = await minMaxDates();
+    this.setState({
+      minDate: dates.releasesMinMax.min,
+      maxDate: dates.releasesMinMax.max
+    });
+    console.log("min: " + dates.releasesMinMax.min);
+    console.log("max: " + dates.releasesMinMax.max);
+  };
   render () {
     const {keyDownUL, sortedData, keyDownAllReleases} = this.props;
     const clearDates = () => {
@@ -82,12 +94,17 @@ class Home extends React.Component {
             focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
             onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
             isOutsideRange = {(day) => {
-              let diffTime = day._d.getTime() - new Date().getTime();
-              const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); 
-              if (diffDays < 2)
-                return false;
-              else
-                return true;
+              // clamp between min and max
+              let diffTime = day._d.getTime() - this.state.maxDate;
+              let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+              if (diffDays < 2) { // all dates before maxDate
+                diffTime = day._d.getTime() - this.state.minDate;
+                diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); 
+                if (diffDays > 0) // dates after minDate
+                  return false;
+              }
+              
+              return true;
             }}
           />
           <button css={xButton} onClick={clearDates}>X</button>


### PR DESCRIPTION
@timarney Noticing that releases for the most recent couple days don't display (i.e. if I set the endDate to today the 19th, the most recent release I see is for the 17th)

Wondering if this is on my end?